### PR TITLE
Fix HTML generation with multiline links

### DIFF
--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -577,9 +577,9 @@ NSString *kOptionDTHTMLEscapeXML = @"DTHTMLEscapeXML";
 		__block NSString *plainSubString = nil; // alwas holds the last plain text from enumarated attributes
 		
 		// ----- SPAN enumeration
-		
+
 		[_attributedString enumerateAttributesInRange:paragraphRange options:0 usingBlock:^(NSDictionary *attributes, NSRange spanRange, BOOL *stopEnumerateAttributes) {
-			
+
 			NSURL *spanURL = nil;
 			
 			if([[attributes objectForKey:DTLinkAttribute] isKindOfClass:[NSURL class]]) {
@@ -640,8 +640,8 @@ NSString *kOptionDTHTMLEscapeXML = @"DTHTMLEscapeXML";
 				}];
 			}
 			
-			// check if previous link is over yet
-			if (currentLinkRange.location != NSNotFound && NSMaxRange(spanRange) <= NSMaxRange(currentLinkRange))
+			// check if the current link tag needs to be closed
+			if (currentLinkRange.location != NSNotFound && (NSMaxRange(spanRange) >= MIN(NSMaxRange(currentLinkRange), NSMaxRange(paragraphRange))))
 			{
 				isLastPartOfHyperlink = YES;
 			}


### PR DESCRIPTION
When link and other attributes (i.e. background) overlap in the attributed string the first closing </a>-tag is not rendered when the link contains a line break.